### PR TITLE
Correctly test if password is not defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
   user: name={{ item.name }}
         password={{ item.password }}
   with_items: sftp_users
-  when: item.password != ''
+  when: item.password is defined and item.password != ""
 
 # Create directories for SFTP users. Optional, but recommended.
 - name: SFTP-Server | Create directories


### PR DESCRIPTION
The previous test would result in an error when no password was defined: 

`error while evaluating conditional: item.password != ''`
