### PR TITLE
Make directory modes customisable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following role variables are relevant:
 * `sftp_home_partition`: The partition where SFTP users' home directories will be located.  Defaults to "/home".
 * `sftp_group_name`: The name of the Unix group to which all SFTP users must belong.  Defaults to "sftpusers".
 * `sftp_directories`: A list of directories that need to be created automatically for each SFTP user.  Defaults to a blank list (i.e. "[]").
+  * Values can be plain strings, or dictionaries containing `name` and (optionally) `mode` key/value pairs.
 * `sftp_allow_passwords`: Whether or not to allow password authentication for SFTP. Defaults to False.
 * `sftp_users`: A list of users, in map form, containing the following elements:
   * `name`: The Unix name of the user that requires SFTP access.
@@ -51,6 +52,7 @@ Example Playbook
     - sftp_directories:
       - imports
       - exports
+      - { name: public, mode: 755 }
       - other
   roles:
     - sftp-server

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,10 +57,10 @@
 
 # Create directories for SFTP users. Optional, but recommended.
 - name: SFTP-Server | Create directories
-  file: path="{{ sftp_home_partition }}/{{ item[0].name }}/{{ item[1] }}"
+  file: path="{{ sftp_home_partition }}/{{ item[0].name }}/{{ item[1].name | default(item[1]) }}"
         owner={{ item[0].name }}
         group={{ item[0].name }}
-        mode="0750"
+        mode="{{ item[1].mode | default(0750) }}"
         state=directory
   with_nested:
     - sftp_users


### PR DESCRIPTION
This change makes it possible to specify custom modes for the standard directories (while maintaining support for the old syntax), e.g.

```
  - sftp_directories:
    - { name: www, mode: 751 }
    - { name: logs, mode: 751 }
    - files
```
