### PR TITLE
make SELinux optional and disable it by default, fix semanage package name for Debian

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@ sftp_home_partition: /home
 sftp_group_name: sftpusers
 sftp_directories: []
 sftp_allow_passwords: False
+sftp_enable_selinux_support: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: SFTP-Server | Ensure SELinux management package is present
   package:
-    name: libsemanage-python
+    name: {{ 'python-semanage' if ansible_distribution == 'Debian' else 'libsemanage-python' }}
     state: present
   when: ansible_selinux
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,9 +22,9 @@
 
 - name: SFTP-Server | Ensure SELinux management package is present
   package:
-    name: {{ 'python-semanage' if ansible_distribution == 'Debian' else 'libsemanage-python' }}
+    name: "{{ 'python-semanage' if ansible_distribution == 'Debian' else 'libsemanage-python' }}"
     state: present
-  when: ansible_selinux
+  when: ansible_selinux and sftp_enable_selinux_support
 
 - name: SFTP-Server | Set SELinux booleans
   seboolean:
@@ -34,7 +34,7 @@
   with_items:
     - ssh_chroot_full_access
     - ssh_chroot_rw_homedirs
-  when: ansible_selinux
+  when: ansible_selinux and sftp_enable_selinux_support
 
 # Create/recreate ssh_config.
 - name: SFTP-Server | Apply sshd_config template


### PR DESCRIPTION
- fix package name for Debian: _python-semanage_ instead of _libsemanage-python_
- make SELinux optional and disable it by default