### PR TITLE
Specify correct path for rsyslog socket

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -126,7 +126,7 @@
     block: |
       # Create an additional socket for some of the sshd chrooted users.
       {% for user in sftp_users %}
-      $AddUnixListenSocket /home/{{ user.name }}/dev/log
+      $AddUnixListenSocket {{ sftp_home_partition }}/{{ user.name }}/dev/log
       {% endfor %}
 
       # Log internal-sftp in a separate file


### PR DESCRIPTION
Hi Johan,

As I was attempting to use this, I realized that this path was not using the path variable as it should have been.

Let me know if you need any further info.
-Erik
