### PR TITLE
Allow multiple match blocks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
 - name: SFTP-Server | Add sshd_config block
   blockinfile:
     dest: /etc/ssh/sshd_config
-    marker: '# {mark} SFTP-Server block'
+    marker: '# {mark} SFTP-Server {{ sftp_group_name }} block'
     block: |
       Match Group {{ sftp_group_name }}
           ChrootDirectory %h


### PR DESCRIPTION
By adding the sftp_group_name in the block marker, one can execute the
role several times with different groups without overriding existing
configuration.
For instance, this can be used to defined 2 stfp groups, one allowing
password authentication and not the other.