### PR TITLE
Extracted user 'nologin' shell path as variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ The following role variables are relevant:
   * `authorized`: An optional list of files placed in `files/` which contain valid public keys for the SFTP user.
   * `sftp_directories`: A list of directories that need to be individually created for an SFTP user. Defaults to a blank list (i.e. "[]").
   * `append`: Boolean to add `sftp_group_name` to the user groups (if any) instead of setting it (default to `False`).
+* `sftp_nologin_shell`: The "nologin" user shell. (defaults to /sbin/nologin.)
+
+Notes:
+* The `sftp_nologin_shell` setting defines the shell assigned to sftp_users when the sftp user's shell is set to False. (The nologin shell ensures the user may only use SFTP and have no other login permissions.) This value may vary depending on the operating system version.
 
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ sftp_directories: []
 sftp_allow_passwords: False
 sftp_enable_selinux_support: False
 sftp_enable_logging: False
+sftp_nologin_shell: /sbin/nologin

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,7 @@
     append: "{{ item.append | default(False) }}"
     home: "{{ sftp_home_partition }}/{{ item.name }}"
     # `None` means default value -> default is to have a shell
-    shell: "{{ None if (item.shell | default(True)) else '/sbin/nologin' }}"
+    shell: "{{ None if (item.shell | default(True)) else sftp_nologin_shell }}"
     state: present
   with_items: "{{ sftp_users }}"
 

--- a/tests/Dockerfile.centos-6.ansible-2.2.2.0
+++ b/tests/Dockerfile.centos-6.ansible-2.2.2.0
@@ -7,6 +7,7 @@ RUN yum install -y openssh-server epel-release libffi-devel gcc
 # Install Ansible
 RUN yum install -y python-pip python-devel openssl-devel
 #software-properties-common git  python-dev libffi-dev libssl-dev
+RUN pip install --upgrade pip
 RUN pip install -U setuptools
 RUN pip install 'ansible==2.2.2.0'
 

--- a/tests/Dockerfile.centos-6.ansible-2.3.0.0
+++ b/tests/Dockerfile.centos-6.ansible-2.3.0.0
@@ -7,6 +7,7 @@ RUN yum install -y openssh-server epel-release libffi-devel gcc
 # Install Ansible
 RUN yum install -y python-pip python-devel openssl-devel
 #software-properties-common git  python-dev libffi-dev libssl-dev
+RUN pip install --upgrade pip
 RUN pip install -U setuptools
 RUN pip install 'ansible==2.3.0.0'
 


### PR DESCRIPTION
Extracted user 'nologin' shell path as variable, defaulting to original hardcoded value.

This provides a solution for issue #24 where the hardcoded value for a no-shell-access user's shell program (/sbin/nologin) is not correct for all platforms.