### PR TITLE
Add passing test for Ubuntu 18.04 + Ansible 2.5.0.

### DIFF
--- a/run-local-tests.sh
+++ b/run-local-tests.sh
@@ -22,6 +22,8 @@ run_test ubuntu 14.04 2.3.0.0
 run_test ubuntu 16.04 2.2.2.0
 run_test ubuntu 16.04 2.3.0.0
 
+run_test ubuntu 18.04 2.5.0.0
+
 run_test centos 6 2.2.2.0
 run_test centos 6 2.3.0.0
 

--- a/tests/Dockerfile.ubuntu-18.04.ansible-2.5.0.0
+++ b/tests/Dockerfile.ubuntu-18.04.ansible-2.5.0.0
@@ -1,0 +1,13 @@
+FROM ubuntu:18.04
+RUN apt-get update
+
+# Install OpenSSH server
+RUN apt-get install -y openssh-server
+
+# Install Ansible
+RUN apt-get install -y software-properties-common git python-pip python-dev libffi-dev libssl-dev
+RUN pip install -U setuptools
+RUN pip install 'ansible==2.5.0.0'
+
+# Install Ansible inventory file
+RUN mkdir /etc/ansible/ && echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts


### PR DESCRIPTION
To minizing testing time, I didn't add all the other
possible combinations of OS version and Ansible version
involving Ubuntu 18.04 and Ansible 2.5.0.