### PR TITLE
Allow setting of home directory mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following role variables are relevant:
   * `authorized`: An optional list of files placed in `files/` which contain valid public keys for the SFTP user.
   * `sftp_directories`: A list of directories that need to be individually created for an SFTP user. Defaults to a blank list (i.e. "[]").
   * `append`: Boolean to add `sftp_group_name` to the user groups (if any) instead of setting it (default to `False`).
+  * `mode`: The users home directory mode (defaults to `0750`).
 * `sftp_nologin_shell`: The "nologin" user shell. (defaults to /sbin/nologin.)
 
 Notes:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,7 +68,7 @@
     path: "{{ sftp_home_partition }}/{{ item.name }}"
     owner: root
     group: "{{ item.group | default(sftp_group_name) }}"
-    mode: "0750"
+    mode: "{{ item.mode | default(0750) }}"
   with_items: "{{ sftp_users }}"
 
 # Install all relevant public keys.


### PR DESCRIPTION
I needed different permissions on my users home directories. This retains the default but allows you to set a mode on a user to change the directory permissions.