### PR TITLE
Custom umask suppport

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following role variables are relevant:
 * `sftp_allow_passwords`: Whether or not to allow password authentication for SFTP. Defaults to False.
 * `sftp_enable_selinux_support`: Whether or not to explicitly enable SELinux support. Defaults to False.
 * `sftp_enable_logging`: Enable logging. Auth logs will be written to `/var/log/sftp/auth.log`, and SFTP activity logs will be written to `/var/log/sftp/verbose.log`. Defaults to False.
+* `sftp_umask`: A string representing a umask value to be used by the sftp server process. Defaults to an empty string, in which case the OS default will be used.
 * `sftp_users`: A list of users, in map form, containing the following elements:
   * `name`: The Unix name of the user that requires SFTP access.
   * `group`: An optional user primary group. If set, it will be used for the user's home permission. Otherwise, the `sftp_group_name` is used.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,4 @@ sftp_allow_passwords: False
 sftp_enable_selinux_support: False
 sftp_enable_logging: False
 sftp_nologin_shell: /sbin/nologin
+sftp_umask: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,7 +48,7 @@
           AllowTCPForwarding no
           PermitTunnel no
           X11Forwarding no
-          ForceCommand internal-sftp {{ sftp_enable_logging | ternary('-l VERBOSE', '') }} {{ (sftp_start_directory in sftp_directories or sftp_start_directory in sftp_directories | selectattr("name", "defined") | map(attribute='name') | list) | ternary('-d /' + sftp_start_directory, '') }}
+          ForceCommand internal-sftp {{ sftp_enable_logging | ternary('-l VERBOSE', '') }} {{ (sftp_start_directory in sftp_directories or sftp_start_directory in sftp_directories | selectattr("name", "defined") | map(attribute='name') | list) | ternary('-d /' + sftp_start_directory, '') }} {{ ('-u ' + sftp_umask) if sftp_umask else '' }}
           PasswordAuthentication {{ sftp_allow_passwords | ternary('yes', 'no') }}
   notify: SFTP-Server | Restart sshd
 


### PR DESCRIPTION
Adds support for setting a custom umask for the sftp server process.  Related to #56.