### PR TITLE
Alternative way to compute the list of STFP users

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,8 @@
 ---
 - name: "Compute SFTP users."
   set_fact:
-    _sftp_users: >-
-      [{% for sftp_user in sftp_users -%}
-        {{ sftp_user | combine({'home': sftp_user.home | default(sftp_home_partition + '/' + sftp_user.name) }) }}
-        {{ '' if loop.last else ',' }}
-      {%- endfor %}]
+    _sftp_users: "{{ _sftp_users | default([]) + [item | combine({'home': item.home | default(sftp_home_partition + '/' + item.name) })] }}"
+  loop: "{{ sftp_users }}"
 
 # Creates group for SFTP users.
 - name: SFTP-Server | Create sftp user group


### PR DESCRIPTION
Fixes #61

Here is an alternative way of computing the list of SFTP users using the ansible `loop` feature instead of the jinja2 `for` one.

Inspired from some [code](https://ericsysmin.com/2024/03/26/using-ansible-set_fact-to-generate-lists-of-objects/) of [Eric Anderson](https://opseric.com/author/ericsysmin/).
